### PR TITLE
Build errors fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "tslib": "^2.0.1",
     "tslint": "~6.1.3",
     "typescript": "~3.8.3",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.10.3",
+    "ace-builds": "^1.4.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.1",
   "scripts": {
     "cleanup": "rm -rf ./target",
-    "getthingsboard": "git clone --depth 1 git@github.com:thingsboard/thingsboard.git ./target/git-tmp/thingsboard",
+    "getthingsboard": "git clone --depth 1 https://github.com/thingsboard/thingsboard.git ./target/git-tmp/thingsboard",
     "ng": "ng",
     "start": "node --max_old_space_size=8048 ./node_modules/@angular/cli/bin/ng serve",
     "build": "ng build && node install.js",

--- a/projects/rulenode-core-config/tsconfig.lib.json
+++ b/projects/rulenode-core-config/tsconfig.lib.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "declaration": true,
     "inlineSources": true,
+    "module": "esnext",
     "types": ["node", "jquery", "flot", "tooltipster", "tinycolor2", "js-beautify", "jstree", "raphael", "canvas-gauges", "mousetrap"],
     "lib": [
       "dom",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,10 @@
       "@core/*": ["node_modules/thingsboard/src/app/core/*"],
       "@shared/*": ["node_modules/thingsboard/src/app/shared/*"],
       "@modules/*": ["node_modules/thingsboard/src/app/modules/*"],
-      "@home/*": ["node_modules/thingsboard/src/app/modules/home/*"]
+      "@home/*": ["node_modules/thingsboard/src/app/modules/home/*"],
+      "ace": [
+        "node_modules/ace-builds/src-noconflict/ace.js"
+      ]
     }
   }
 }


### PR DESCRIPTION
### 1. Error
Getting error when repo url starts with git@git...

```
yarn run v1.22.5
$ git clone --depth 1 git@github.com:thingsboard/thingsboard.git ./target/git-tmp/thingsboard
Cloning into './target/git-tmp/thingsboard2'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error Command failed with exit code 128.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Solution :  https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/18/commits/9a2a5229293a435d0fa7160df593c3d23d0ec725 

### 2. Build error

fix `error TS2307: Cannot find module 'ace'.`

Solution: https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/18/commits/b4d1ce956e880144160d8f90e6fca90abf1443c4

### 3. Build error

` error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.`

```
ERROR: node_modules/thingsboard/src/app/shared/models/ace/ace.models.ts:30:30 - error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.

30     aceObservables.push(from(import('ace-builds/src-noconflict/ext-language_tools')));
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/thingsboard/src/app/shared/models/ace/ace.models.ts:31:30 - error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.

31     aceObservables.push(from(import('ace-builds/src-noconflict/ext-searchbox')));
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/thingsboard/src/app/shared/models/ace/ace.models.ts:32:30 - error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.

32     aceObservables.push(from(import('ace-builds/src-noconflict/mode-java')));
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/thingsboard/src/app/shared/models/ace/ace.models.ts:33:30 - error TS1323: Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.

....

```
Solution : https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/18/commits/487d932db42e6a609442869e13c42792378c5091
