### PR TITLE
Add checkbox toggle for HTTP Client rule node ignoreRequestBody

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/action/rest-api-call-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/action/rest-api-call-config.component.html
@@ -21,6 +21,9 @@
   <mat-checkbox *ngIf="!restApiCallConfigForm.get('enableProxy').value" formControlName="useSimpleClientHttpFactory" style="padding-bottom: 16px;">
     {{ 'tb.rulenode.use-simple-client-http-factory' | translate }}
   </mat-checkbox>
+  <mat-checkbox formControlName="ignoreRequestBody" style="padding-bottom: 16px;">
+    {{ 'tb.rulenode.ignore-request-body' | translate }}
+  </mat-checkbox>
   <div *ngIf="restApiCallConfigForm.get('enableProxy').value">
     <mat-checkbox formControlName="useSystemProxyProperties" style="padding-bottom: 16px;">
       {{ 'tb.rulenode.use-system-proxy-properties' | translate }}

--- a/projects/rulenode-core-config/src/lib/components/action/rest-api-call-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/action/rest-api-call-config.component.ts
@@ -32,6 +32,7 @@ export class RestApiCallConfigComponent extends RuleNodeConfigurationComponent {
       restEndpointUrlPattern: [configuration ? configuration.restEndpointUrlPattern : null, [Validators.required]],
       requestMethod: [configuration ? configuration.requestMethod : null, [Validators.required]],
       useSimpleClientHttpFactory: [configuration ? configuration.useSimpleClientHttpFactory : false, []],
+      ignoreRequestBody: [configuration ? configuration.ignoreRequestBody : false, []],
       enableProxy: [configuration ? configuration.enableProxy : false, []],
       useSystemProxyProperties: [configuration ? configuration.enableProxy : false, []],
       proxyScheme: [configuration ? configuration.proxyHost : null, []],

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -156,6 +156,7 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           'endpoint-url-pattern-required': 'Endpoint URL pattern is required',
           'request-method': 'Request method',
           'use-simple-client-http-factory': 'Use simple client HTTP factory',
+          'ignore-request-body': 'Without request body',
           'read-timeout': 'Read timeout in millis',
           'read-timeout-hint': 'The value of 0 means an infinite timeout',
           'max-parallel-requests-count': 'Max number of parallel requests',


### PR DESCRIPTION
This PR provides a checkbox UI for the new `ignoreRequestBody` option in thingsboard/thingsboard#5304. This does not include an translations.

<img width="712" alt="Screen shot of the new HTTP Client rule node ignoreRequestBody option" src="https://user-images.githubusercontent.com/139448/135531719-63413ccf-81b0-4bea-b0dd-48b80dd012a0.png">