### PR TITLE
Enrichment nodes: hint for pattern usage in attributes mapping added

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.html
@@ -34,6 +34,7 @@
         <mat-icon>close</mat-icon>
       </button>
     </div>
+    <div *ngIf="hintText" class="tb-hint" [innerHTML]="hintText | translate | safeHtml"></div>
   </div>
   <tb-error [error]="ngControl.hasError('kvMapRequired')
                   ? translate.instant(requiredText) : ''"></tb-error>

--- a/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.scss
+++ b/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.scss
@@ -23,11 +23,6 @@
       max-height: 300px;
       overflow: auto;
 
-      .row {
-        padding-top: 5px;
-        max-height: 40px;
-      }
-
       .cell {
         padding-left: 5px;
         padding-right: 5px;
@@ -41,7 +36,6 @@
     .body {
       mat-form-field.cell {
         margin: 0px;
-        max-height: 40px;
 
         .mat-form-field-infix {
           border-top: 0;
@@ -50,6 +44,7 @@
 
       button.mat-button {
         margin: 0;
+        align-self: baseline;
       }
     }
   }

--- a/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/common/kv-map-config.component.ts
@@ -45,6 +45,8 @@ export class KvMapConfigComponent extends PageComponent implements ControlValueA
 
   @Input() valRequiredText: string;
 
+  @Input() hintText: string;
+
   private requiredValue: boolean;
   get required(): boolean {
     return this.requiredValue;

--- a/projects/rulenode-core-config/src/lib/components/enrichment/customer-attributes-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/customer-attributes-config.component.html
@@ -10,6 +10,7 @@
     keyText="{{ customerAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry' : 'tb.rulenode.source-attribute' }}"
     keyRequiredText="{{ customerAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry-required' : 'tb.rulenode.source-attribute-required' }}"
     valText="tb.rulenode.target-attribute"
-    valRequiredText="tb.rulenode.target-attribute-required">
+    valRequiredText="tb.rulenode.target-attribute-required"
+    hintText="tb.rulenode.kv-map-pattern-hint">
   </tb-kv-map-config>
 </section>

--- a/projects/rulenode-core-config/src/lib/components/enrichment/related-attributes-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/related-attributes-config.component.html
@@ -16,6 +16,7 @@
     keyText="{{ relatedAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry' : 'tb.rulenode.source-attribute' }}"
     keyRequiredText="{{ relatedAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry-required' : 'tb.rulenode.source-attribute-required' }}"
     valText="tb.rulenode.target-attribute"
-    valRequiredText="tb.rulenode.target-attribute-required">
+    valRequiredText="tb.rulenode.target-attribute-required"
+    hintText="tb.rulenode.kv-map-pattern-hint">
   </tb-kv-map-config>
 </section>

--- a/projects/rulenode-core-config/src/lib/components/enrichment/tenant-attributes-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/tenant-attributes-config.component.html
@@ -10,6 +10,7 @@
     keyText="{{ tenantAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry' : 'tb.rulenode.source-attribute' }}"
     keyRequiredText="{{ tenantAttributesConfigForm.get('telemetry').value ? 'tb.rulenode.source-telemetry-required' : 'tb.rulenode.source-attribute-required' }}"
     valText="tb.rulenode.target-attribute"
-    valRequiredText="tb.rulenode.target-attribute-required">
+    valRequiredText="tb.rulenode.target-attribute-required"
+    hintText="tb.rulenode.kv-map-pattern-hint">
   </tb-kv-map-config>
 </section>

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -427,7 +427,10 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
             'for value from metadata, <code><span style="color: #000;">$[</span>messageKey<span style="color: #000;">]</span></code> ' +
             'for value from message body. Alarm severity should be system (CRITICAL, MAJOR etc.)',
           'output-node-name-hint': 'The <b>rule node name</b> corresponds to the <b>relation type</b> of the output message, and it is used to forward messages to other rule nodes in the caller rule chain.',
-          'skip-latest-persistence': 'Skip latest persistence'
+          'skip-latest-persistence': 'Skip latest persistence',
+          'kv-map-pattern-hint': 'Hint: use <code><span style="color: #000;">$&#123;</span>metadataKey<span style="color: #000;">&#125;</span></code> ' +
+            'for value from metadata, <code><span style="color: #000;">$[</span>messageKey<span style="color: #000;">]</span></code> ' +
+            'for value from message body to substitute "Source" and "Target" key names',
         },
         'key-val': {
           key: 'Key',


### PR DESCRIPTION
Hint for pattern usage in attributes mapping added for nodes:
- customer attributes
- tenant attributes
- related attributes

Related to https://github.com/thingsboard/thingsboard/pull/5550