### PR TITLE
[3.4.2] Add retain button to the MQTT rule node

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/action/mqtt-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/action/mqtt-config.component.html
@@ -54,6 +54,9 @@
   <mat-checkbox formControlName="cleanSession">
     {{ 'tb.rulenode.clean-session' | translate }}
   </mat-checkbox>
+  <mat-checkbox formControlName="retainedMessage">
+    {{ "tb.rulenode.retained-message" | translate }}
+  </mat-checkbox>
   <mat-checkbox formControlName="ssl">
     {{ 'tb.rulenode.enable-ssl' | translate }}
   </mat-checkbox>

--- a/projects/rulenode-core-config/src/lib/components/action/mqtt-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/action/mqtt-config.component.ts
@@ -38,6 +38,7 @@ export class MqttConfigComponent extends RuleNodeConfigurationComponent implemen
         disabled: !(configuration && isNotEmptyStr(configuration.clientId))
       }, []],
       cleanSession: [configuration ? configuration.cleanSession : false, []],
+      retainedMessage: [configuration ? configuration.retainedMessage : false, []],
       ssl: [configuration ? configuration.ssl : false, []],
       credentials: [configuration ? configuration.credentials : null, []]
     });

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -481,6 +481,7 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           'custom-expression-field-input': 'Mathematical Expression',
           'custom-expression-field-input-required': 'Mathematical expression is required',
           'custom-expression-field-input-hint': 'Hint: specify a mathematical expression to evaluate. For example, transform Fahrenheit to Celsius using <i>(x - 32) / 1.8)</i>',
+          "retained-message": "Retained",
         },
         'key-val': {
           key: 'Key',


### PR DESCRIPTION
## Pull Request description  
Previously we created an issue, #7384, that we were not able to send retained MQTT messages in the rule chains. With this pull request we added a checkbox in the configuration where the user can specifiy if they want to send retained messages.

### UI Changes
#### Old:
![old message screenshot](https://user-images.githubusercontent.com/18370066/194567294-e68481a7-4fb1-4ac4-b928-da3758328193.png)

#### New:
![Retained message screenshot](https://user-images.githubusercontent.com/18370066/194567318-35d2a686-7692-44ae-835d-84d21e218dd8.png)