### PR TITLE
[3.4.2]: optional key pattern field for Kafka rule node

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/action/kafka-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/action/kafka-config.component.html
@@ -7,6 +7,12 @@
     </mat-error>
     <mat-hint [innerHTML]="'tb.rulenode.general-pattern-hint' | translate | safeHtml"></mat-hint>
   </mat-form-field>
+  <mat-form-field class="mat-block" style="padding-bottom: 8px;">
+    <mat-label translate>tb.rulenode.key-pattern</mat-label>
+    <input matInput formControlName="keyPattern">
+    <mat-hint [innerHTML]="'tb.rulenode.general-pattern-hint' | translate | safeHtml"></mat-hint>
+  </mat-form-field>
+  <div class="tb-hint" translate>tb.rulenode.key-pattern-hint</div>
   <mat-form-field class="mat-block">
     <mat-label translate>tb.rulenode.bootstrap-servers</mat-label>
     <input required matInput formControlName="bootstrapServers">

--- a/projects/rulenode-core-config/src/lib/components/action/kafka-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/action/kafka-config.component.ts
@@ -31,6 +31,7 @@ export class KafkaConfigComponent extends RuleNodeConfigurationComponent {
   protected onConfigurationSet(configuration: RuleNodeConfiguration) {
     this.kafkaConfigForm = this.fb.group({
       topicPattern: [configuration ? configuration.topicPattern : null, [Validators.required]],
+      keyPattern: [configuration ? configuration.keyPattern : null],
       bootstrapServers: [configuration ? configuration.bootstrapServers : null, [Validators.required]],
       retries: [configuration ? configuration.retries : null, [Validators.min(0)]],
       batchSize: [configuration ? configuration.batchSize : null, [Validators.min(0)]],

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -175,6 +175,10 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           value: 'Value',
           'value-required': 'Value is required',
           'topic-pattern': 'Topic pattern',
+          'key-pattern': 'Key pattern',
+          'key-pattern-hint': 'Hint: Optional. If a valid partition number is specified, it will be used when sending the record. ' +
+                              'If no partition is specified, the key will be used instead. '+
+                              'If neither is specified, a partition will be assigned in a round-robin fashion.',
           'topic-pattern-required': 'Topic pattern is required',
           topic: 'Topic',
           'topic-required': 'Topic is required',


### PR DESCRIPTION
## Pull Request description

issue: [#4865](https://github.com/thingsboard/thingsboard/issues/4865)
corresponding backend PR: https://github.com/thingsboard/thingsboard/pull/7425

It is now possible to configure a _Key pattern_ on the Kafka rule node. Prior, they key was hard-coded to _null_. From the Kafka [ProducerRecord documentation](https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html):
> If no partition is specified but a key is present a partition will be chosen using a hash of the key. If neither key nor partition is present a partition will be assigned in a round-robin fashion. 

The [external nodes documentation](https://thingsboard.io/docs/user-guide/rule-engine-2-0/external-nodes/#kafka-node) should be updated with an updated screenshot of the configuration form and a short description of the new form field.

### UI before change
![image](https://user-images.githubusercontent.com/64529640/195852549-30229bc6-5629-4e96-a7dd-8dc63ea9fdfc.png)

### UI after change
![image](https://user-images.githubusercontent.com/64529640/195853152-452d899e-4530-4682-b085-28df50da0563.png)
