### PR TITLE
Fixed missing translation in enrichment customer/tenant details rule nodes

### DIFF
--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -404,7 +404,7 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           'output-timeseries-key-prefix-required': 'Output timeseries key prefix required.',
           'separator-hint': 'You should press "enter" to complete field input.',
           'entity-details': 'Select entity details:',
-          'entity-details-id': 'ID',
+          'entity-details-id': 'Id',
           'entity-details-title': 'Title',
           'entity-details-country': 'Country',
           'entity-details-state': 'State',

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -404,6 +404,7 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           'output-timeseries-key-prefix-required': 'Output timeseries key prefix required.',
           'separator-hint': 'You should press "enter" to complete field input.',
           'entity-details': 'Select entity details:',
+          'entity-details-id': 'ID',
           'entity-details-title': 'Title',
           'entity-details-country': 'Country',
           'entity-details-state': 'State',

--- a/projects/rulenode-core-config/src/lib/rulenode-core-config.models.ts
+++ b/projects/rulenode-core-config/src/lib/rulenode-core-config.models.ts
@@ -82,6 +82,7 @@ export enum EntityDetailsField {
 
 export const entityDetailsTranslations = new Map<EntityDetailsField, string>(
   [
+    [EntityDetailsField.ID, 'tb.rulenode.entity-details-id'],
     [EntityDetailsField.TITLE, 'tb.rulenode.entity-details-title'],
     [EntityDetailsField.COUNTRY, 'tb.rulenode.entity-details-country'],
     [EntityDetailsField.STATE, 'tb.rulenode.entity-details-state'],


### PR DESCRIPTION
Before:
![Screenshot from 2023-02-15 13-22-10](https://user-images.githubusercontent.com/87172504/219016171-5ace92f3-0995-4094-aad4-528f062ae3eb.png)

After: 
![Screenshot from 2023-02-15 15-52-17](https://user-images.githubusercontent.com/87172504/219046121-b31362ae-6c81-4e64-b6df-63d7bca64aa9.png)

