### PR TITLE
Added filtering of entityFields in Originator field node

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/enrichment/originator-fields-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/originator-fields-config.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { AppState, deepTrim, isDefinedAndNotNull } from '@core/public-api';
-import { entityFields, RuleNodeConfiguration, RuleNodeConfigurationComponent } from '@shared/public-api';
+import { RuleNodeConfiguration, RuleNodeConfigurationComponent } from '@shared/public-api';
 import { Store } from '@ngrx/store';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { FetchTo, SvMapOption } from '../../rulenode-core-config.models';
+import { FetchTo, SvMapOption, allowedOriginatorFields } from '../../rulenode-core-config.models';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -19,10 +19,10 @@ export class OriginatorFieldsConfigComponent extends RuleNodeConfigurationCompon
               private fb: FormBuilder,
               private translate: TranslateService) {
     super(store);
-    for (const field of Object.keys(entityFields)) {
+    for (const field of allowedOriginatorFields) {
       this.originatorFields.push({
-        value: entityFields[field].value,
-        name: this.translate.instant(entityFields[field].name)
+        value: field.value,
+        name: this.translate.instant(field.name)
       });
     }
   }

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -5,6 +5,8 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
     const enUS = {
       tb: {
         rulenode: {
+          id: 'Id',
+          'additional-info': 'Additional Info',
           'create-entity-if-not-exists': 'Create new entity if not exists',
           'create-entity-if-not-exists-hint': 'Create a new entity set above if it does not exist.',
           'entity-name-pattern': 'Name pattern',

--- a/projects/rulenode-core-config/src/lib/rulenode-core-config.models.ts
+++ b/projects/rulenode-core-config/src/lib/rulenode-core-config.models.ts
@@ -1,4 +1,4 @@
-import { EntitySearchDirection, EntityTypeFilter } from '@shared/public-api';
+import { EntityField, entityFields, EntitySearchDirection, EntityTypeFilter } from '@shared/public-api';
 
 export enum OriginatorSource {
   CUSTOMER = 'CUSTOMER',
@@ -17,6 +17,26 @@ export const originatorSourceTranslations = new Map<OriginatorSource, string>(
     [OriginatorSource.ENTITY, 'tb.rulenode.originator-entity'],
   ]
 );
+
+export const allowedOriginatorFields: EntityField[] = [
+    entityFields.createdTime,
+    entityFields.name,
+    entityFields.type,
+    entityFields.firstName,
+    entityFields.lastName,
+    entityFields.email,
+    entityFields.title,
+    entityFields.country,
+    entityFields.state,
+    entityFields.city,
+    entityFields.address,
+    entityFields.address2,
+    entityFields.zip,
+    entityFields.phone,
+    entityFields.label,
+    {value: 'id', name: 'tb.rulenode.id', keyName: 'id'},
+    {value: 'additionalInfo', name: 'tb.rulenode.additional-info', keyName: 'additionalInfo'}
+];
 
 export enum PerimeterType {
   CIRCLE = 'CIRCLE',


### PR DESCRIPTION
It is wrong to use just entityFields in the originator fields node.  
Some values aren't supported in PE version, plus "id" and "additionalInfo" aren't represented in entityFields.

Issue: https://github.com/thingsboard/thingsboard/issues/9341
