### PR TITLE
tb-string-items-list added transformation null data into empty array

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/common/select-attributes.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/common/select-attributes.component.ts
@@ -68,7 +68,7 @@ export class SelectAttributesComponent implements OnInit, ControlValueAccessor, 
     const formatValue = {};
     for (const key in propagateValue) {
       if (key === 'getLatestValueWithTs') {
-        formatValue[key] = propagateValue;
+        formatValue[key] = propagateValue[key];
       } else {
         formatValue[key] = isDefinedAndNotNull(propagateValue[key]) ? propagateValue[key] : [];
       }

--- a/projects/rulenode-core-config/src/lib/components/common/select-attributes.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/common/select-attributes.component.ts
@@ -13,6 +13,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { COMMA, ENTER, SEMICOLON } from '@angular/cdk/keycodes';
 import { TranslateService } from '@ngx-translate/core';
+import { isDefinedAndNotNull } from '@core/public-api';
 
 @Component({
   selector: 'tb-select-attributes',
@@ -46,10 +47,10 @@ export class SelectAttributesComponent implements OnInit, ControlValueAccessor, 
 
   ngOnInit(): void {
     this.attributeControlGroup = this.fb.group({
-      clientAttributeNames: [null, []],
-      sharedAttributeNames: [null, []],
-      serverAttributeNames: [null, []],
-      latestTsKeyNames: [null, []],
+      clientAttributeNames: [[], []],
+      sharedAttributeNames: [[], []],
+      serverAttributeNames: [[], []],
+      latestTsKeyNames: [[], []],
       getLatestValueWithTs: [false, []]
     }, {
       validators: this.atLeastOne(Validators.required, ['clientAttributeNames', 'sharedAttributeNames',
@@ -59,9 +60,22 @@ export class SelectAttributesComponent implements OnInit, ControlValueAccessor, 
     this.attributeControlGroup.valueChanges.pipe(
       takeUntil(this.destroy$)
     ).subscribe((value) => {
-      this.propagateChange(value);
+      this.propagateChange(this.preparePropagateValue(value));
     });
   }
+
+  private preparePropagateValue(propagateValue: {[key: string]: string[] | boolean | null}): {[key: string]: string[] | boolean } {
+    const formatValue = {};
+    for (const key in propagateValue) {
+      if (key === 'getLatestValueWithTs') {
+        formatValue[key] = propagateValue;
+      } else {
+        formatValue[key] = isDefinedAndNotNull(propagateValue[key]) ? propagateValue[key] : [];
+      }
+    };
+
+    return formatValue;
+  };
 
   validate() {
     if (this.attributeControlGroup.valid) {

--- a/projects/rulenode-core-config/src/lib/components/enrichment/device-attributes-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/device-attributes-config.component.ts
@@ -37,10 +37,10 @@ export class DeviceAttributesConfigComponent extends RuleNodeConfigurationCompon
   protected prepareInputConfig(configuration: RuleNodeConfiguration): RuleNodeConfiguration {
     if (isObject(configuration)) {
       configuration.attributesControl = {
-        clientAttributeNames: isDefinedAndNotNull(configuration?.clientAttributeNames) ? configuration.clientAttributeNames : null,
-        latestTsKeyNames: isDefinedAndNotNull(configuration?.latestTsKeyNames) ? configuration.latestTsKeyNames : null,
-        serverAttributeNames: isDefinedAndNotNull(configuration?.serverAttributeNames) ? configuration.serverAttributeNames : null,
-        sharedAttributeNames: isDefinedAndNotNull(configuration?.sharedAttributeNames) ? configuration.sharedAttributeNames : null,
+        clientAttributeNames: isDefinedAndNotNull(configuration?.clientAttributeNames) ? configuration.clientAttributeNames : [],
+        latestTsKeyNames: isDefinedAndNotNull(configuration?.latestTsKeyNames) ? configuration.latestTsKeyNames : [],
+        serverAttributeNames: isDefinedAndNotNull(configuration?.serverAttributeNames) ? configuration.serverAttributeNames : [],
+        sharedAttributeNames: isDefinedAndNotNull(configuration?.sharedAttributeNames) ? configuration.sharedAttributeNames : [],
         getLatestValueWithTs: isDefinedAndNotNull(configuration?.getLatestValueWithTs) ? configuration.getLatestValueWithTs : false,
       };
     }

--- a/projects/rulenode-core-config/src/lib/components/enrichment/originator-attributes-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/enrichment/originator-attributes-config.component.ts
@@ -36,10 +36,10 @@ export class OriginatorAttributesConfigComponent extends RuleNodeConfigurationCo
   protected prepareInputConfig(configuration: RuleNodeConfiguration): RuleNodeConfiguration {
     if (isObject(configuration)) {
       configuration.attributesControl = {
-        clientAttributeNames: isDefinedAndNotNull(configuration?.clientAttributeNames) ? configuration.clientAttributeNames : null,
-        latestTsKeyNames: isDefinedAndNotNull(configuration?.latestTsKeyNames) ? configuration.latestTsKeyNames : null,
-        serverAttributeNames: isDefinedAndNotNull(configuration?.serverAttributeNames) ? configuration.serverAttributeNames : null,
-        sharedAttributeNames: isDefinedAndNotNull(configuration?.sharedAttributeNames) ? configuration.sharedAttributeNames : null,
+        clientAttributeNames: isDefinedAndNotNull(configuration?.clientAttributeNames) ? configuration.clientAttributeNames : [],
+        latestTsKeyNames: isDefinedAndNotNull(configuration?.latestTsKeyNames) ? configuration.latestTsKeyNames : [],
+        serverAttributeNames: isDefinedAndNotNull(configuration?.serverAttributeNames) ? configuration.serverAttributeNames : [],
+        sharedAttributeNames: isDefinedAndNotNull(configuration?.sharedAttributeNames) ? configuration.sharedAttributeNames : [],
         getLatestValueWithTs: isDefinedAndNotNull(configuration?.getLatestValueWithTs) ? configuration.getLatestValueWithTs : false
       };
     }

--- a/projects/rulenode-core-config/src/lib/components/filter/check-message-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/filter/check-message-config.component.ts
@@ -24,11 +24,20 @@ export class CheckMessageConfigComponent extends RuleNodeConfigurationComponent 
 
   protected prepareInputConfig(configuration: RuleNodeConfiguration): RuleNodeConfiguration {
     return {
-      messageNames: isDefinedAndNotNull(configuration?.messageNames) ? configuration.messageNames : null,
-      metadataNames: isDefinedAndNotNull(configuration?.metadataNames) ? configuration.metadataNames : null,
+      messageNames: isDefinedAndNotNull(configuration?.messageNames) ? configuration.messageNames : [],
+      metadataNames: isDefinedAndNotNull(configuration?.metadataNames) ? configuration.metadataNames : [],
       checkAllKeys: isDefinedAndNotNull(configuration?.checkAllKeys) ? configuration.checkAllKeys : false
     };
   }
+
+  protected prepareOutputConfig(configuration: RuleNodeConfiguration): RuleNodeConfiguration {
+    return {
+      messageNames: isDefinedAndNotNull(configuration?.messageNames) ? configuration.messageNames : [],
+      metadataNames: isDefinedAndNotNull(configuration?.metadataNames) ? configuration.metadataNames : [],
+      checkAllKeys: configuration.checkAllKeys
+    };
+  }
+
 
   private atLeastOne(validator: ValidatorFn, controls: string[] = null) {
     return (group: FormGroup): ValidationErrors | null => {


### PR DESCRIPTION
The logic of tb-string-items-list puts null into the control key in case the user cleans the field. Some rule-nodes for empty fields expecting not null but empty array. 

So this PR adds transformation null into empty array for all tb-sting-item-list components that don't have 'required' validation.