### PR TITLE
Fix translation in "alarm status filter" node

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/common/alarm-status-select.component.html
+++ b/projects/rulenode-core-config/src/lib/components/common/alarm-status-select.component.html
@@ -13,7 +13,7 @@
         {{ alarmStatusTranslations.get(alarmStatus.CLEARED_UNACK) | translate }}
       </mat-chip-option>
       <mat-chip-option fxFlex class="option" [value]="alarmStatus.CLEARED_ACK">
-        {{ alarmStatusTranslations.get(alarmStatus.ACTIVE_UNACK) | translate }}
+        {{ alarmStatusTranslations.get(alarmStatus.CLEARED_ACK) | translate }}
       </mat-chip-option>
     </div>
   </mat-chip-listbox>


### PR DESCRIPTION
Before:
![image](https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/assets/43555187/cdc39aff-5c85-4937-85af-94abafd7ce40)
After:
![image](https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/assets/43555187/2635f7f4-4365-42a2-a544-f61e34f720e6)
