### PR TITLE
REST API call node: max response size parameter added

### DIFF
--- a/projects/rulenode-core-config/src/lib/components/external/rest-api-call-config.component.html
+++ b/projects/rulenode-core-config/src/lib/components/external/rest-api-call-config.component.html
@@ -82,6 +82,11 @@
     <input type="number" step="1" min="0" matInput formControlName="maxParallelRequestsCount">
     <mat-hint translate>tb.rulenode.max-parallel-requests-count-hint</mat-hint>
   </mat-form-field>
+  <mat-form-field class="mat-block" subscriptSizing="dynamic">
+    <mat-label translate>tb.rulenode.max-response-size</mat-label>
+    <input type="number" step="1" min="1" matInput formControlName="maxInMemoryBufferSizeInKb">
+    <mat-hint translate>tb.rulenode.max-response-size-hint</mat-hint>
+  </mat-form-field>
   <label translate class="tb-title">tb.rulenode.headers</label>
   <div class="tb-hint" [innerHTML]="'tb.rulenode.headers-hint' | translate | safe: 'html'">  </div>
   <tb-kv-map-config-old

--- a/projects/rulenode-core-config/src/lib/components/external/rest-api-call-config.component.ts
+++ b/projects/rulenode-core-config/src/lib/components/external/rest-api-call-config.component.ts
@@ -44,7 +44,8 @@ export class RestApiCallConfigComponent extends RuleNodeConfigurationComponent {
       readTimeoutMs: [configuration ? configuration.readTimeoutMs : null, []],
       maxParallelRequestsCount: [configuration ? configuration.maxParallelRequestsCount : null, [Validators.min(0)]],
       headers: [configuration ? configuration.headers : null, []],
-      credentials: [configuration ? configuration.credentials : null, []]
+      credentials: [configuration ? configuration.credentials : null, []],
+      maxInMemoryBufferSizeInKb: [configuration ? configuration.maxInMemoryBufferSizeInKb : null, [Validators.min(1)]]
     });
   }
 

--- a/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
+++ b/projects/rulenode-core-config/src/lib/locale/rulenode-core-locale.constant.ts
@@ -275,6 +275,8 @@ export default function addRuleNodeCoreLocaleEnglish(translate: TranslateService
           'read-timeout-hint': 'The value of 0 means an infinite timeout',
           'max-parallel-requests-count': 'Max number of parallel requests',
           'max-parallel-requests-count-hint': 'The value of 0 specifies no limit in parallel processing',
+          'max-response-size': 'Max response size (in KB)',
+          'max-response-size-hint': 'The maximum amount of memory allocated for buffering data when decoding or encoding HTTP messages, such as JSON or XML payloads',
           headers: 'Headers',
           'headers-hint': 'Use <code><span style="color: #000;">$&#123;</span>metadataKey<span style="color: #000;">&#125;</span></code> ' +
             'for value from metadata, <code><span style="color: #000;">$[</span>messageKey<span style="color: #000;">]</span></code> ' +


### PR DESCRIPTION
Related to [#11500](https://github.com/thingsboard/thingsboard/pull/11500)

Some requests in 3.7.0 fail with the following error caused by exceeding the web-client default max buffer size value (256KB).
![image](https://github.com/user-attachments/assets/fcf0b2e5-8d90-4f52-bd7a-d2e29cb8333c)

The new parameter allows the default limit to be increased if needed.
![image](https://github.com/user-attachments/assets/b7cd3acc-b757-494e-bc21-9d42983896bf)

In case of error some additional information will be added to the msg metadata
![image](https://github.com/user-attachments/assets/3ace7bd3-5414-4729-b37b-63474676c510)

